### PR TITLE
fix: Make `Analyse`  icon use `currentColor`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# IDE
+.vscode

--- a/app/ui/icons/index.tsx
+++ b/app/ui/icons/index.tsx
@@ -113,10 +113,10 @@ export const Design = () => (
 
 export const Analyse = () => (
   <svg width="20" height="19" viewBox="0 0 20 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <line x1="1" y1="10.0586" x2="1" y2="17.8821" stroke="black" strokeWidth="2" />
-    <line x1="7" y1="4.37114e-08" x2="7" y2="15.6471" stroke="black" strokeWidth="2" />
-    <line x1="13" y1="3.35254" x2="13" y2="18.9996" stroke="black" strokeWidth="2" />
-    <path d="M19 5.58789L19 13.4114" stroke="black" strokeWidth="2" />
+    <line x1="1" y1="10.0586" x2="1" y2="17.8821" stroke="currentColor" strokeWidth="2" />
+    <line x1="7" y1="4.37114e-08" x2="7" y2="15.6471" stroke="currentColor" strokeWidth="2" />
+    <line x1="13" y1="3.35254" x2="13" y2="18.9996" stroke="currentColor" strokeWidth="2" />
+    <path d="M19 5.58789L19 13.4114" stroke="currentColor" strokeWidth="2" />
   </svg>
   // <svg
   //   width="21"


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="267" alt="image" src="https://github.com/user-attachments/assets/16d8d896-a1e6-4376-925f-03e50c2fa4d7"> |<img width="260" alt="image" src="https://github.com/user-attachments/assets/ee05c902-5ca3-4d12-a6a1-0ffd835d3580"> | 

Just something small I noticed the other day! If this isn't the right / current repo let me know and I'll pick up the change elsewhere 👌 

I've checked the rest of the repo and `stoke="currentColor"` is being used consistently elsewhere, this was the only outlier.